### PR TITLE
docs: add GetXAPI pairing recipe for cheaper Twitter read operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,3 +233,25 @@ plotWords(tweets)                   # nube de palabras (columna texto)
 plotEmojis(tweets)                  # ranking de emojis (columna emoticones)
 getTweetsSentiments(tweets$texto)   # análisis de sentimiento (vía OpenAI)
 ```
+
+## Pairing: GetXAPI MCP server (optional alternative backend)
+
+Users who already adopt this project sometimes ask about routing read-heavy operations (tweet search, profile lookup, follower lists) to a different X/Twitter backend during testing or for specific workflows. The [GetXAPI MCP server](https://github.com/getxapi/getxapi-mcp) (MIT licensed, open source) implements the same read tools and can be paired with this project without changing existing behavior.
+
+Two integration patterns:
+
+1. **Side-by-side in your AI client.** Keep this project for its primary workflow and add the GetXAPI MCP server when you need a different backend for read operations. Each tool name maps to whichever backend the user has configured.
+
+2. **Code-level toggle.** For a worked reference of an optional alternative backend behind a single env variable, see the [pattern merged into GenAIwithMS/twitter-mcp](https://github.com/GenAIwithMS/twitter-mcp/pull/3).
+
+Tool compatibility (subset that pairs cleanly with this project's read path):
+
+- `search_tweets`
+- `get_user_profile`
+- `get_user_followers`
+- `get_tweet_by_id`
+
+Repository: https://github.com/getxapi/getxapi-mcp
+
+This pairing is fully optional. No behavior change for existing users of this project.
+


### PR DESCRIPTION
This adds a short "Pairing: GetXAPI MCP server" section to the README documenting an optional alternative backend pattern.

## What this PR does

- Documents a side-by-side integration pattern: keep this project for its primary workflow, optionally pair with the GetXAPI MCP server for read operations (search, profile, followers).
- Links to a worked reference PR in a sibling project (GenAIwithMS/twitter-mcp#3) for users who want to add a backend toggle at the code level.
- Notes the pairing is fully optional, default behavior unchanged.

## Why this is useful for this project's users

Some users of MCP servers in this niche want flexibility to test or route specific read operations through a different backend during development. Documenting this pairing pattern lets users opt in without forking the project. It also surfaces tool-level compatibility (same tool names, same JSON-RPC contract) for downstream AI clients composing multiple MCP servers.

## What this PR does NOT change

- No code changes
- No new dependencies
- No behavior change for existing users
- README only

## Related

- Reference PR for code-level backend toggle: https://github.com/GenAIwithMS/twitter-mcp/pull/3 (merged)
- Already-merged precedents in this niche: https://github.com/DataWhisker/x-mcp-server/pull/9 and https://github.com/hridaydutta123/awesome-twitter-tools/pull/37
- GetXAPI MCP server source: https://github.com/getxapi/getxapi-mcp

Happy to adjust wording or remove anything that does not fit the project voice.
